### PR TITLE
bsoutham/logout

### DIFF
--- a/pkg/cloudvolume/cvcontext_test.go
+++ b/pkg/cloudvolume/cvcontext_test.go
@@ -10,37 +10,31 @@ func init() {
 	context.DefaultDBOpenFunc = context.MockOpen
 }
 
-func TestStoreContext(t *testing.T) {
-	if err := storeContext("host1", "blahKey"); err != nil {
+func TestSaveData(t *testing.T) {
+	if err := saveData("host1.cloud", "blah-token-value"); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestStoreContextFailsEmptyKey(t *testing.T) {
-	if err := storeContext("", "blahKey"); err == nil {
-		t.Fatal("expected failure no empty key")
-	}
-}
-
-func TestStoreGetWorks(t *testing.T) {
+func TestGetWorks(t *testing.T) {
 	const h1 = "host1"
 
 	const v1 = "value1"
 
-	if err := storeContext(h1, v1); err != nil {
+	if err := saveData(h1, v1); err != nil {
 		t.Fatal(err)
 	}
 
-	d, err := getContext()
+	gotHost, gotToken, err := hostAndToken()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if d.Host != h1 {
-		t.Fatal("didn't retrieve matching host value")
+	if gotHost != h1 {
+		t.Fatal("didn't retrieve matching host")
 	}
 
-	if d.APIKey != v1 {
-		t.Fatal("didn't retrieve matching apikey value")
+	if gotToken != v1 {
+		t.Fatal("didn't retrieve matching value")
 	}
 }

--- a/pkg/cloudvolume/login.go
+++ b/pkg/cloudvolume/login.go
@@ -52,7 +52,7 @@ func runCVLogin(_ *cobra.Command, _ []string) error {
 
 	// change context to current host and save the token as the API key
 	// for subsequent requests
-	if err := storeContext(cvLoginData.host, token); err != nil {
+	if err := saveData(cvLoginData.host, token); err != nil {
 		logger.Warning("Successfully logged into CloudVolumes, but was unable to save the session data")
 		logger.Debug("%+v", err)
 	} else {

--- a/pkg/cloudvolume/login_test.go
+++ b/pkg/cloudvolume/login_test.go
@@ -29,22 +29,24 @@ func TestLoginWorks(t *testing.T) {
 	cvLoginData.host = ts.URL
 
 	// erase value from db - so we know it is empty
-	storeContext(ts.URL, "")
+	saveData(ts.URL, "")
 
 	err := runCVLogin(nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	d, err := getContext()
+	gotHost, gotToken, err := hostAndToken()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got := d.APIKey
+	if gotHost != ts.URL {
+		t.Fatalf(errTempl, gotHost, want)
+	}
 
-	if got != want {
-		t.Fatalf(errTempl, got, want)
+	if gotToken != want {
+		t.Fatalf(errTempl, gotHost, want)
 	}
 }
 

--- a/pkg/cloudvolume/volumes.go
+++ b/pkg/cloudvolume/volumes.go
@@ -19,16 +19,16 @@ var cmdGetVolumes = &cobra.Command{
 func runCVGetVolumes(_ *cobra.Command, _ []string) error {
 	logger.Debug("Beginning runCVGetVolumes")
 
-	c, err := getContext()
+	host, token, err := hostAndToken()
 	if err != nil {
 		logger.Debug("unable to retrieve apiKey because of: %#v", err)
 		return fmt.Errorf("unable to retrieve the last login for HPE CloudVolumes." +
 			"Please login to CloudVolumes using: hpecli cloudvolume login")
 	}
 
-	logger.Debug("Attempting get cloud volumes at: %v", c.Host)
+	logger.Debug("Attempting get cloud volumes at: %v", host)
 
-	cvc := NewCVClientFromAPIKey(c.Host, c.APIKey)
+	cvc := NewCVClientFromAPIKey(host, token)
 
 	jsonResult, err := cvc.GetCloudVolumes()
 	if err != nil {

--- a/pkg/cloudvolume/volumes_test.go
+++ b/pkg/cloudvolume/volumes_test.go
@@ -42,7 +42,7 @@ func TestRunCVGetVolumes(t *testing.T) {
 	// delete the default store
 	_ = os.Remove(f)
 
-	storeContext(ts.URL, "someAPIKey")
+	saveData(ts.URL, "someAPIKey")
 
 	err := runCVGetVolumes(nil, nil)
 	if err != nil {

--- a/pkg/context/apikey.go
+++ b/pkg/context/apikey.go
@@ -119,7 +119,7 @@ func (c APIContext) RemoveContext(key string) error {
 	defer d.Close()
 
 	// Delete context key
-	if err := d.Delete(c.ContextKey); err != nil {
+	if err := d.Delete(key); err != nil {
 		return fmt.Errorf("unable to delete context because of %#v", err)
 	}
 

--- a/pkg/context/apikey.go
+++ b/pkg/context/apikey.go
@@ -11,6 +11,7 @@ type Context interface {
 	APIKey(value interface{}) error
 	SetAPIKey(key string, value interface{}) error
 	ChangeContext(key string) error
+	RemoveContext(key string) error
 }
 
 type DBOpenFunc func() (db.Store, error)
@@ -101,6 +102,25 @@ func (c APIContext) ChangeContext(key string) error {
 	// Save context key
 	if err := d.Put(c.ContextKey, key); err != nil {
 		return fmt.Errorf("unable to save current context because of %#v", err)
+	}
+
+	return nil
+}
+
+func (c APIContext) RemoveContext(key string) error {
+	if key == "" {
+		return ErrorInvalidKey
+	}
+
+	d, err := c.DBOpen()
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	// Delete context key
+	if err := d.Delete(c.ContextKey); err != nil {
+		return fmt.Errorf("unable to delete context because of %#v", err)
 	}
 
 	return nil

--- a/pkg/context/apikey_test.go
+++ b/pkg/context/apikey_test.go
@@ -161,6 +161,14 @@ func TestSetAPIFailsOnDBOpen(t *testing.T) {
 	}
 }
 
+func TestRemoveContextDeleteFails(t *testing.T) {
+	c := withMockStore()
+
+	if err := c.RemoveContext("fail"); err == nil {
+		t.Fatalf(errExpected)
+	}
+}
+
 func TestChangeContextPutFails(t *testing.T) {
 	c := withMockStore()
 

--- a/pkg/context/mock.go
+++ b/pkg/context/mock.go
@@ -10,6 +10,8 @@ import (
 	"github.com/HewlettPackard/hpecli/pkg/db"
 )
 
+var ErrorExpected = errors.New("expected error")
+
 type MockStore struct {
 	m map[string][]byte
 }
@@ -22,7 +24,7 @@ func MockOpen() (db.Store, error) {
 
 func (ms *MockStore) Get(key string, value interface{}) error {
 	if strings.Contains(key, "fail") {
-		return errors.New("expected error")
+		return ErrorExpected
 	}
 
 	d := gob.NewDecoder(bytes.NewReader(ms.m[key]))
@@ -40,7 +42,7 @@ func (ms *MockStore) Put(key string, value interface{}) error {
 	v := fmt.Sprintf("%s", value)
 
 	if strings.Contains(key, "fail") || strings.Contains(v, "fail") {
-		return errors.New("expected error")
+		return ErrorExpected
 	}
 
 	return nil
@@ -48,11 +50,13 @@ func (ms *MockStore) Put(key string, value interface{}) error {
 
 func (ms *MockStore) Delete(key string) error {
 	if strings.Contains(key, "fail") {
-		return errors.New("expected error")
+		return ErrorExpected
 	}
+
 	if _, ok := ms.m[key]; !ok {
 		return db.ErrNotFound
 	}
+
 	delete(ms.m, key)
 
 	return nil

--- a/pkg/context/mock.go
+++ b/pkg/context/mock.go
@@ -47,7 +47,11 @@ func (ms *MockStore) Put(key string, value interface{}) error {
 }
 
 func (ms *MockStore) Delete(key string) error {
+	if strings.Contains(key, "fail") {
+		return errors.New("expected error")
+	}
 	delete(ms.m, key)
+
 	return nil
 }
 

--- a/pkg/context/mock.go
+++ b/pkg/context/mock.go
@@ -50,6 +50,9 @@ func (ms *MockStore) Delete(key string) error {
 	if strings.Contains(key, "fail") {
 		return errors.New("expected error")
 	}
+	if _, ok := ms.m[key]; !ok {
+		return db.ErrNotFound
+	}
 	delete(ms.m, key)
 
 	return nil

--- a/pkg/greenlake/context.go
+++ b/pkg/greenlake/context.go
@@ -31,5 +31,5 @@ func runSetContext(_ *cobra.Command, _ []string) error {
 		glContextHost.host = fmt.Sprintf("https://%s", glContextHost.host)
 	}
 
-	return changeContext(glContextHost.host)
+	return setContext(glContextHost.host)
 }

--- a/pkg/greenlake/context_test.go
+++ b/pkg/greenlake/context_test.go
@@ -31,7 +31,7 @@ func TestGLContextIsSetInDB(t *testing.T) {
 	// sets the context in the DB
 	_ = runSetContext(nil, nil)
 
-	_, err := getContext()
+	_, err := getData()
 	if !errors.Is(err, context.ErrorKeyNotFound) {
 		t.Fatal("expected to find the context but not the key")
 	}

--- a/pkg/greenlake/login.go
+++ b/pkg/greenlake/login.go
@@ -53,7 +53,7 @@ func runGLLogin(_ *cobra.Command, _ []string) error {
 
 	// change context to current host and save the access token as the API key
 	// for subsequent requests
-	if err = storeContext(glLoginData.host, glLoginData.tenantID, token); err != nil {
+	if err = saveData(glLoginData.host, glLoginData.tenantID, token); err != nil {
 		logger.Warning("Successfully logged into GreenLake, but was unable to save the session data")
 	} else {
 		logger.Debug("Successfully logged into GreenLake: %s", glLoginData.host)

--- a/pkg/greenlake/login_test.go
+++ b/pkg/greenlake/login_test.go
@@ -49,7 +49,7 @@ func TestGLAccessTokenIsStored(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, _ := getContext()
+	c, _ := getData()
 	if c.APIKey != accessToken {
 		t.Fatalf(errTempl, c.APIKey, accessToken)
 	}

--- a/pkg/greenlake/users.go
+++ b/pkg/greenlake/users.go
@@ -19,7 +19,7 @@ var cmdGetUsers = &cobra.Command{
 func runGLGetUsers(_ *cobra.Command, _ []string) error {
 	logger.Debug("Beginning runGLGetUsers")
 
-	c, err := getContext()
+	c, err := getData()
 	if err != nil {
 		logger.Debug("unable to retrieve apiKey because of: %#v", err)
 		return fmt.Errorf("unable to retrieve the last login for HPE GreenLake." +

--- a/pkg/greenlake/users_test.go
+++ b/pkg/greenlake/users_test.go
@@ -31,7 +31,7 @@ func TestGLAPIKeyInjectedIntoRequest(t *testing.T) {
 	defer server.Close()
 
 	// set context to the test server host
-	storeContext(server.URL, tenantID, authValue)
+	saveData(server.URL, tenantID, authValue)
 
 	_ = runGLGetUsers(nil, nil)
 }

--- a/pkg/ilo/context.go
+++ b/pkg/ilo/context.go
@@ -30,5 +30,5 @@ func runSetContext(_ *cobra.Command, _ []string) error {
 		iloContextHost.host = fmt.Sprintf("https://%s", iloContextHost.host)
 	}
 
-	return changeContext(iloContextHost.host)
+	return setContext(iloContextHost.host)
 }

--- a/pkg/ilo/context_test.go
+++ b/pkg/ilo/context_test.go
@@ -3,7 +3,6 @@
 package ilo
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -25,14 +24,25 @@ func TestHostPrefixAddedForContext(t *testing.T) {
 	}
 }
 
-func TestContextIsSetInDB(t *testing.T) {
-	iloContextHost.host = "127.0.0.1"
+func TestGetWorks(t *testing.T) {
+	const h1 = "host1"
 
-	// sets the context in the DB
-	_ = runSetContext(nil, nil)
+	const v1 = "value1"
 
-	_, err := getContext()
-	if !errors.Is(err, context.ErrorKeyNotFound) {
-		t.Fatal("expected to find the context but not the key")
+	if err := saveData(h1, v1); err != nil {
+		t.Fatal(err)
+	}
+
+	gotHost, gotToken, err := hostAndToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotHost != h1 {
+		t.Fatal("didn't retrieve matching host")
+	}
+
+	if gotToken != v1 {
+		t.Fatal("didn't retrieve matching value")
 	}
 }

--- a/pkg/ilo/ilocontext.go
+++ b/pkg/ilo/ilocontext.go
@@ -9,26 +9,40 @@ import (
 const iloAPIKeyPrefix = "hpecli_ilo_token_"
 const iloContextKey = "hpecli_ilo_context"
 
-type iloContextData struct {
-	Host   string
-	APIKey string
+func hostAndToken() (host, token string, err error) {
+	c := context.New(iloContextKey)
+
+	host, err = c.ModuleContext()
+	if err != nil {
+		return "", "", err
+	}
+
+	if err = c.HostData(dataKey(host), &token); err != nil {
+		return "", "", err
+	}
+
+	return host, token, nil
 }
 
-func storeContext(key, token string) error {
-	c := context.New(iloContextKey, iloAPIKeyPrefix)
-	return c.SetAPIKey(key, &iloContextData{key, token})
+func saveData(host, token string) error {
+	c := context.New(iloContextKey)
+	if err := c.SetModuleContext(host); err != nil {
+		return err
+	}
+
+	return c.SetHostData(dataKey(host), token)
 }
 
-func getContext() (*iloContextData, error) {
-	c := context.New(iloContextKey, iloAPIKeyPrefix)
-
-	var d iloContextData
-	err := c.APIKey(&d)
-
-	return &d, err
+func setContext(host string) error {
+	c := context.New(iloContextKey)
+	return c.SetModuleContext(host)
 }
 
-func changeContext(key string) error {
-	c := context.New(iloContextKey, iloAPIKeyPrefix)
-	return c.ChangeContext(key)
+func deleteSavedData(host string) error {
+	c := context.New(iloContextKey)
+	return c.DeleteHostData(dataKey(host))
+}
+
+func dataKey(apiEndpoint string) string {
+	return iloAPIKeyPrefix + apiEndpoint
 }

--- a/pkg/ilo/login.go
+++ b/pkg/ilo/login.go
@@ -49,7 +49,7 @@ func runILOLogin(_ *cobra.Command, _ []string) error {
 
 	// change context to current host and save the session ID as the API key
 	// for subsequent requests
-	if err = storeContext(iloLoginData.host, token); err != nil {
+	if err = saveData(iloLoginData.host, token); err != nil {
 		logger.Warning("Successfully logged into ilo, but was unable to save the session data")
 	} else {
 		logger.Debug("Successfully logged into ilo: %s", iloLoginData.host)

--- a/pkg/ilo/login_test.go
+++ b/pkg/ilo/login_test.go
@@ -48,8 +48,12 @@ func TestAPIKeyIsStored(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c, _ := getContext()
-	if c.APIKey != sessionID {
-		t.Fatalf(errTempl, c.APIKey, sessionID)
+	h, k, _ := hostAndToken()
+	if h != iloLoginData.host {
+		t.Fatalf(errTempl, h, iloLoginData.host)
+	}
+
+	if k != sessionID {
+		t.Fatalf(errTempl, k, sessionID)
 	}
 }

--- a/pkg/ilo/serviceroot.go
+++ b/pkg/ilo/serviceroot.go
@@ -19,16 +19,16 @@ var cmdILOServiceRoot = &cobra.Command{
 func runILOServiceRoot(_ *cobra.Command, _ []string) error {
 	logger.Debug("Beginning runILOServiceRoot")
 
-	c, err := getContext()
+	host, token, err := hostAndToken()
 	if err != nil {
 		logger.Debug("unable to retrieve apiKey because of: %#v", err)
 		return fmt.Errorf("unable to retrieve the last login for HPE iLO." +
 			"Please login to iLO using: hpecli ilo login")
 	}
 
-	logger.Debug("Attempting get ilo service root at: %v", c.Host)
+	logger.Debug("Attempting get ilo service root at: %v", host)
 
-	client := NewILOClientFromAPIKey(c.Host, c.APIKey)
+	client := NewILOClientFromAPIKey(host, token)
 
 	jsonResult, err := client.GetServiceRoot()
 	if err != nil {

--- a/pkg/ilo/serviceroot_test.go
+++ b/pkg/ilo/serviceroot_test.go
@@ -28,7 +28,7 @@ func TestAPIKeyInjectedIntoRequest(t *testing.T) {
 	defer server.Close()
 
 	// set context to the test server host
-	storeContext(server.URL, authValue)
+	saveData(server.URL, authValue)
 
 	_ = runILOServiceRoot(nil, nil)
 }

--- a/pkg/oneview/client.go
+++ b/pkg/oneview/client.go
@@ -47,6 +47,7 @@ func NewOVClientFromAPIKey(host, apikey string) *ov.OVClient {
 	}
 }
 
+// Login creates a OneView session
 func Login(host, username, password string) (string, error) {
 	const uriPath = "/rest/login-sessions"
 
@@ -78,6 +79,7 @@ func Login(host, username, password string) (string, error) {
 	return "", fmt.Errorf("unable to session Token from login request")
 }
 
+// AddAPIHeaders sets OneView API version
 func AddAPIHeaders() func(*rest.Request) {
 	return func(r *rest.Request) {
 		r.Header.Set("X-API-Version", "800")

--- a/pkg/oneview/context.go
+++ b/pkg/oneview/context.go
@@ -30,5 +30,5 @@ func runChangeContext(_ *cobra.Command, _ []string) error {
 		ovContextHost.host = fmt.Sprintf("https://%s", ovContextHost.host)
 	}
 
-	return changeContext(ovContextHost.host)
+	return setContext(ovContextHost.host)
 }

--- a/pkg/oneview/context_test.go
+++ b/pkg/oneview/context_test.go
@@ -31,7 +31,7 @@ func TestContextIsSetInDB(t *testing.T) {
 	// sets the context in the DB
 	_ = runChangeContext(nil, nil)
 
-	_, err := getContext()
+	_, _, err := hostAndToken()
 	// we have set the context but not the apikey value
 	// so we should get a ErrorKeyNotFound
 	if !errors.Is(err, context.ErrorKeyNotFound) {

--- a/pkg/oneview/enclosures.go
+++ b/pkg/oneview/enclosures.go
@@ -31,18 +31,18 @@ func getEnclosures(_ *cobra.Command, _ []string) error {
 }
 
 func getEnclosuresData() error {
-	d, err := getContext()
+	host, token, err := hostAndToken()
 	if err != nil {
 		logger.Debug("unable to retrieve apiKey because of: %#v", err)
 		return fmt.Errorf("unable to retrieve the last login for OneView." +
 			"Please login to OneView using: hpecli oneview login")
 	}
 
-	ovc := NewOVClientFromAPIKey(d.Host, d.APIKey)
+	ovc := NewOVClientFromAPIKey(host, token)
 
 	// not sure we want to show the host we are retieving from.
 	// it's good to know - but then breaks json data format being returned
-	logger.Always("Retrieving data from: %s", d.Host)
+	logger.Always("Retrieving data from: %s", host)
 
 	var el interface{}
 
@@ -53,7 +53,7 @@ func getEnclosuresData() error {
 	}
 
 	if err != nil {
-		logger.Warning("Unable to login with supplied credentials to OneView at: %s", d.Host)
+		logger.Warning("Unable to login with supplied credentials to OneView at: %s", host)
 		return err
 	}
 

--- a/pkg/oneview/enclosures_test.go
+++ b/pkg/oneview/enclosures_test.go
@@ -30,7 +30,7 @@ func TestAPIKeyPutInEnclosureRequest(t *testing.T) {
 	defer server.Close()
 
 	// set context to the test server host
-	storeContext(server.URL, sessionID)
+	saveContextAndHostData(server.URL, sessionID)
 
 	// check is above in the http request handler side
 	_ = getEnclosuresData()
@@ -47,7 +47,7 @@ func TestEnclosureClientRequestFails(t *testing.T) {
 	defer server.Close()
 
 	// set context to the test server host
-	storeContext(server.URL, sessionID)
+	saveContextAndHostData(server.URL, sessionID)
 
 	// check is above in the http request handler side
 	if err := getEnclosures(nil, nil); err == nil {
@@ -67,7 +67,7 @@ func TestEnclosureJSONMarshallFails(t *testing.T) {
 	defer server.Close()
 
 	// set context to the test server host
-	storeContext(server.URL, sessionID)
+	saveContextAndHostData(server.URL, sessionID)
 
 	// check is above in the http request handler side
 	if err := getEnclosuresData(); err == nil {
@@ -87,7 +87,7 @@ func TestGetEnclosureByName(t *testing.T) {
 	defer server.Close()
 
 	// set context to the test server host
-	storeContext(server.URL, "sessionID")
+	saveContextAndHostData(server.URL, "sessionID")
 
 	if err := getEnclosuresData(); err != nil {
 		t.Fatal(err)

--- a/pkg/oneview/login.go
+++ b/pkg/oneview/login.go
@@ -48,7 +48,7 @@ func runOVLogin(_ *cobra.Command, _ []string) error {
 
 	// change context to current host and save the session ID as the API key
 	// for subsequent requests
-	if err = storeContext(ovLoginData.host, token); err != nil {
+	if err = saveContextAndHostData(ovLoginData.host, token); err != nil {
 		logger.Warning("Successfully logged into OneView, but was unable to save the session data")
 	} else {
 		logger.Debug("Successfully logged into OneView: %s", ovLoginData.host)

--- a/pkg/oneview/login_test.go
+++ b/pkg/oneview/login_test.go
@@ -52,10 +52,10 @@ func TestAPIKeyIsStored(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, _ := getContext()
+	_, token, _ := hostAndToken()
 
-	if got.APIKey != sessionID {
-		t.Fatalf(errTempl, got.APIKey, sessionID)
+	if token != sessionID {
+		t.Fatalf(errTempl, token, sessionID)
 	}
 }
 

--- a/pkg/oneview/logout.go
+++ b/pkg/oneview/logout.go
@@ -1,0 +1,50 @@
+// (C) Copyright 2019 Hewlett Packard Enterprise Development LP.
+
+package oneview
+
+import (
+	"fmt"
+
+	"github.com/HewlettPackard/hpecli/pkg/logger"
+	"github.com/spf13/cobra"
+)
+
+// ovLogoutCmd represents the oneview ovLoginCmd command
+var ovLogoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Logout from OneView: hpecli oneview logout",
+	RunE:  runOVLogout,
+}
+
+func init() {
+}
+
+func runOVLogout(_ *cobra.Command, _ []string) error {
+	d, err := getContext()
+	if err != nil {
+		logger.Debug("unable to retrieve apiKey because of: %#v", err)
+		return fmt.Errorf("unable to retrieve the last login for OneView." +
+			"Please login to OneView using: hpecli oneview login")
+	}
+
+	ovc := NewOVClientFromAPIKey(d.Host, d.APIKey)
+
+	logger.Always("Retrieving data from: %s", d.Host)
+
+	// Use OVClient to logout
+	err = ovc.SessionLogout()
+	if err != nil {
+		logger.Warning("Unable to logout from OneView at: %s", d.Host)
+		return err
+	}
+	/*
+	// Cleanup context
+	if err = removeContext(d.host); err != nil {
+		logger.Warning("Successfully logged off OneView, but was unable to cleanup the session data")
+	} else {
+		logger.Debug("Successfully logged off OneView: %s", d.host)
+	}
+	*/
+
+	return nil
+}

--- a/pkg/oneview/logout.go
+++ b/pkg/oneview/logout.go
@@ -12,6 +12,7 @@ import (
 var ovLogoutHost struct {
 	host string
 }
+
 // ovLogoutCmd represents the oneview ovLoginCmd command
 var ovLogoutCmd = &cobra.Command{
 	Use:   "logout",
@@ -41,13 +42,13 @@ func runOVLogout(_ *cobra.Command, _ []string) error {
 		logger.Warning("Unable to logout from OneView at: %s", d.Host)
 		return err
 	}
-	
+
 	// Cleanup context
-	err = removeContext(d.Host)
+	err = removeContext()
 	if err != nil {
 		logger.Warning("Unable to cleanup the session data")
 		return err
-	} 
+	}
 
 	return nil
 }

--- a/pkg/oneview/logout.go
+++ b/pkg/oneview/logout.go
@@ -17,6 +17,7 @@ var ovLogoutCmd = &cobra.Command{
 }
 
 func init() {
+	ovContextCmd.Flags().StringVar(&ovContextHost.host, "host", "", "oneview host/ip address")
 }
 
 func runOVLogout(_ *cobra.Command, _ []string) error {
@@ -37,14 +38,13 @@ func runOVLogout(_ *cobra.Command, _ []string) error {
 		logger.Warning("Unable to logout from OneView at: %s", d.Host)
 		return err
 	}
-	/*
+	
 	// Cleanup context
-	if err = removeContext(d.host); err != nil {
-		logger.Warning("Successfully logged off OneView, but was unable to cleanup the session data")
-	} else {
-		logger.Debug("Successfully logged off OneView: %s", d.host)
-	}
-	*/
+	err = removeContext(d.Host)
+	if err != nil {
+		logger.Warning("Unable to cleanup the session data")
+		return err
+	} 
 
 	return nil
 }

--- a/pkg/oneview/logout.go
+++ b/pkg/oneview/logout.go
@@ -9,6 +9,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var ovLogoutHost struct {
+	host string
+}
 // ovLogoutCmd represents the oneview ovLoginCmd command
 var ovLogoutCmd = &cobra.Command{
 	Use:   "logout",
@@ -17,7 +20,7 @@ var ovLogoutCmd = &cobra.Command{
 }
 
 func init() {
-	ovContextCmd.Flags().StringVar(&ovContextHost.host, "host", "", "oneview host/ip address")
+	ovLogoutCmd.Flags().StringVar(&ovLogoutHost.host, "host", "", "oneview host/ip address")
 }
 
 func runOVLogout(_ *cobra.Command, _ []string) error {

--- a/pkg/oneview/logout_test.go
+++ b/pkg/oneview/logout_test.go
@@ -7,10 +7,13 @@ import (
 	"testing"
 )
 
-func TestClientLogoutRequestFails(t *testing.T) {
+const logoutURI = "/rest/login-sessions"
+const expectedErrMsg = "expected to see an error here but didn't"
+
+func TestLogoutRequestFails(t *testing.T) {
 	const sessionID = "HERE_IS_A_ID"
 
-	server := newTestServer(shURL, func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(logoutURI, func(w http.ResponseWriter, r *http.Request) {
 		// cause the request to fail
 		w.WriteHeader(http.StatusBadRequest)
 	})
@@ -22,6 +25,37 @@ func TestClientLogoutRequestFails(t *testing.T) {
 
 	// check is above in the http request handler side
 	if err := runOVLogout(nil, nil); err == nil {
-		t.Fatal("expected to get an error")
+		t.Fatal(expectedErrMsg)
+	}
+}
+
+func TestLogoutRemovesContext(t *testing.T) {
+	const sessionID = "HERE_IS_A_ID"
+
+	server := newTestServer(logoutURI, func(w http.ResponseWriter, r *http.Request) {
+		// cause the request to fail
+		w.WriteHeader(http.StatusOK)
+	})
+
+	defer server.Close()
+
+	// set context to the test server host
+	_ = storeContext(server.URL, sessionID)
+
+	// check is above in the http request handler side
+	_ = runOVLogout(nil, nil)
+
+	if _, err := getContext(); err == nil {
+		t.Fatal(expectedErrMsg)
+	}
+}
+
+func TestLogoutFailsWhenItCantGetContext(t *testing.T) {
+	// erase context for runnig the command
+	_ = removeContext()
+
+	// run the command that will fail because of the missing context
+	if err := runOVLogout(nil, nil); err == nil {
+		t.Fatal(expectedErrMsg)
 	}
 }

--- a/pkg/oneview/logout_test.go
+++ b/pkg/oneview/logout_test.go
@@ -1,0 +1,33 @@
+// (C) Copyright 2019 Hewlett Packard Enterprise Development LP.
+
+package oneview
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/HewlettPackard/hpecli/pkg/context"
+)
+
+func init() {
+	context.DefaultDBOpenFunc = context.MockOpen
+}
+
+func TestClientLogoutRequestFails(t *testing.T) {
+	const sessionID = "HERE_IS_A_ID"
+
+	server := newTestServer(shURL, func(w http.ResponseWriter, r *http.Request) {
+		// cause the request to fail
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	defer server.Close()
+
+	// set context to the test server host
+	_ = storeContext(server.URL, sessionID)
+
+	// check is above in the http request handler side
+	if err := runOVLogout(nil, nil); err == nil {
+		t.Fatal("expected to get an error")
+	}
+}

--- a/pkg/oneview/logout_test.go
+++ b/pkg/oneview/logout_test.go
@@ -5,13 +5,7 @@ package oneview
 import (
 	"net/http"
 	"testing"
-
-	"github.com/HewlettPackard/hpecli/pkg/context"
 )
-
-func init() {
-	context.DefaultDBOpenFunc = context.MockOpen
-}
 
 func TestClientLogoutRequestFails(t *testing.T) {
 	const sessionID = "HERE_IS_A_ID"

--- a/pkg/oneview/oneview.go
+++ b/pkg/oneview/oneview.go
@@ -16,4 +16,6 @@ func init() {
 	Cmd.AddCommand(ovContextCmd)
 	Cmd.AddCommand(ovGetCmd)
 	Cmd.AddCommand(ovLoginCmd)
+	Cmd.AddCommand(ovLogoutCmd)
+	
 }

--- a/pkg/oneview/oneview.go
+++ b/pkg/oneview/oneview.go
@@ -17,5 +17,4 @@ func init() {
 	Cmd.AddCommand(ovGetCmd)
 	Cmd.AddCommand(ovLoginCmd)
 	Cmd.AddCommand(ovLogoutCmd)
-	
 }

--- a/pkg/oneview/ovcontext.go
+++ b/pkg/oneview/ovcontext.go
@@ -33,7 +33,7 @@ func changeContext(key string) error {
 	return c.ChangeContext(key)
 }
 
-func removeContext(key string) error {
+func removeContext() error {
 	c := context.New(oneViewContextKey, oneViewAPIKeyPrefix)
-	return c.RemoveContext(key)
+	return c.RemoveContext(oneViewContextKey)
 }

--- a/pkg/oneview/ovcontext.go
+++ b/pkg/oneview/ovcontext.go
@@ -32,3 +32,8 @@ func changeContext(key string) error {
 	c := context.New(oneViewContextKey, oneViewAPIKeyPrefix)
 	return c.ChangeContext(key)
 }
+
+func removeContext(key string) error {
+	c := context.New(oneViewContextKey, oneViewAPIKeyPrefix)
+	return c.RemoveContext(key)
+}

--- a/pkg/oneview/servers.go
+++ b/pkg/oneview/servers.go
@@ -31,16 +31,16 @@ func getServers(_ *cobra.Command, _ []string) error {
 }
 
 func getServerHardware() error {
-	d, err := getContext()
+	host, token, err := hostAndToken()
 	if err != nil {
 		logger.Debug("unable to retrieve apiKey because of: %#v", err)
 		return fmt.Errorf("unable to retrieve the last login for OneView." +
 			"Please login to OneView using: hpecli oneview login")
 	}
 
-	ovc := NewOVClientFromAPIKey(d.Host, d.APIKey)
+	ovc := NewOVClientFromAPIKey(host, token)
 
-	logger.Always("Retrieving data from: %s", d.Host)
+	logger.Always("Retrieving data from: %s", host)
 
 	var sh interface{}
 	if ovServersData.name != "" {
@@ -50,7 +50,7 @@ func getServerHardware() error {
 	}
 
 	if err != nil {
-		logger.Warning("Unable to login with supplied credentials to OneView at: %s", d.Host)
+		logger.Warning("Unable to login with supplied credentials to OneView at: %s", host)
 		return err
 	}
 

--- a/pkg/oneview/servers_test.go
+++ b/pkg/oneview/servers_test.go
@@ -30,7 +30,7 @@ func TestAPIKeyPutInServerRequest(t *testing.T) {
 	defer server.Close()
 
 	// set context to the test server host
-	_ = storeContext(server.URL, sessionID)
+	_ = saveContextAndHostData(server.URL, sessionID)
 
 	// check is above in the http request handler side
 	_ = getServerHardware()
@@ -47,7 +47,7 @@ func TestClientServerRequestFails(t *testing.T) {
 	defer server.Close()
 
 	// set context to the test server host
-	_ = storeContext(server.URL, sessionID)
+	_ = saveContextAndHostData(server.URL, sessionID)
 
 	// check is above in the http request handler side
 	if err := getServers(nil, nil); err == nil {
@@ -67,7 +67,7 @@ func TestServerJSONMarshallFails(t *testing.T) {
 	defer server.Close()
 
 	// set context to the test server host
-	_ = storeContext(server.URL, sessionID)
+	_ = saveContextAndHostData(server.URL, sessionID)
 
 	// check is above in the http request handler side
 	if err := getServerHardware(); err == nil {


### PR DESCRIPTION
implement oneview logout (from Didier)
rewrite of the apikey/context to allow independent handling of the context and the data

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hewlettpackard/hpecli/55)
<!-- Reviewable:end -->
