### PR TITLE
remote version only on version command

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -2,9 +2,8 @@
 for /f "usebackq tokens=*" %%a in (`git rev-parse --short HEAD`) do set GIT_COMMIT=%%a
 
 SET ISO_DATE=%DATE:~10,4%-%DATE:~4,2%-%DATE:~7,2%
-SET VERSION_FILE=github.com/HewlettPackard/hpecli/pkg/version
 
 @echo on
-go build -o hpecli.exe -ldflags "-X %VERSION_FILE%.version=0.0.1 -X %VERSION_FILE%.buildDate=%ISO_DATE% -X %VERSION_FILE%.gitCommitId=%GIT_COMMIT%" .\cmd\hpecli
+go build -o hpecli.exe -ldflags "-X main.sematicVer=0.0.0 -X main.buildDate=%ISO_DATE% -X main.gitCommitID=%GIT_COMMIT%" .\cmd\hpecli
 
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-DT=`date +%F`
-GC=`git rev-parse --short HEAD`
-VERSION_FILE=github.com/HewlettPackard/hpecli/pkg/version
+ISO_DATE=`date +%F`
+GIT_COMMIT=`git rev-parse --short HEAD`
 
-go build -o hpecli -ldflags "-X '$VERSION_FILE.version=0.0.1' -X '$VERSION_FILE.buildDate=$DT' -X '$VERSION_FILE.gitCommitId=$GC'" ./cmd/hpecli
+go build -o hpecli -ldflags "-X main.sematicVer=0.0.1 -X main.buildDate=$ISO_DATE -X main.gitCommitID=$GIT_COMMIT" ./cmd/hpecli

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/HewlettPackard/hpecli/pkg/version"
 	gover "github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 )
@@ -54,29 +53,29 @@ const EnvDisableUpdateCheck = "HPECLI_DISABLE_UPDATE_CHECK"
 // json file that describes the latest release version.  Should be updated when new versions are published
 // can alternatively change to using github tags once we real releases
 const versionHost = "raw.githubusercontent.com"
+
 const versionPath = "/HewlettPackard/hpecli/master/site/published-version.json"
 
 var versionURL = fmt.Sprintf("https://%s%s", versionHost, versionPath)
 
 var cacheResponse *CheckResponse
 
-// IsUpdateAvailable checks if a later version is avaialbe of the CLI binary
-func IsUpdateAvailable() bool {
-	cliVer := version.Get()
-	logrus.Debug("Local version is: " + cliVer)
+// CheckForUpdate returns data about the availability of an updated version of the CLI
+func CheckForUpdate(localVersion string) (*CheckResponse, error) {
+	logrus.Debug("Local version is: " + localVersion)
 	logrus.Debug("Checking for a newer version at: " + versionURL)
 
-	res, err := checkUpdate(&jsonSource{url: versionURL}, cliVer)
+	res, err := checkUpdate(&jsonSource{url: versionURL}, localVersion)
 	if err != nil {
 		logrus.Debug("Unable to determine if a new version of the CLI is available")
 		logrus.Debugf("Error: %v", err)
 
-		return false
+		return &CheckResponse{}, err
 	}
 
 	logrus.Debugf("%#v", res)
 
-	return res.UpdateAvailable
+	return res, nil
 }
 
 // Check fetches last version information from its source

--- a/pkg/update/check_test.go
+++ b/pkg/update/check_test.go
@@ -33,7 +33,7 @@ func TestIsUpdateAvailableEmptyLocalVersion(t *testing.T) {
 			name:       "no local version",
 			localVer:   "",
 			remoteJSON: `{"version":"0.0.1"}`,
-			update:     true,
+			update:     false,
 		},
 	}
 
@@ -49,9 +49,9 @@ func TestIsUpdateAvailableEmptyLocalVersion(t *testing.T) {
 			})
 			defer server.Close()
 
-			got := IsUpdateAvailable()
-			if got != c.update {
-				t.Fatal("didn't get expected response")
+			got, _ := CheckForUpdate(c.localVer)
+			if got.UpdateAvailable != c.update {
+				t.Fatalf("Incorrect response:  got=%v, want=%v", got.UpdateAvailable, c.update)
 			}
 		})
 	}
@@ -62,8 +62,8 @@ func TestIsUpdateAvailablInvalidURLErrors(t *testing.T) {
 	cacheResponse = nil
 	versionURL = "://badScheme"
 
-	got := IsUpdateAvailable()
-	if got != false {
+	got, _ := CheckForUpdate("0.0.0")
+	if got.UpdateAvailable != false {
 		t.Fatal("error in checkUpdate should generate false response")
 	}
 }
@@ -190,8 +190,8 @@ func TestCachedCopyDoestRetrieveAgain(t *testing.T) {
 		t.Fatal("response to be unititialed before request")
 	}
 
-	got := IsUpdateAvailable()
-	if got != true {
+	got, _ := CheckForUpdate("0.0.0")
+	if got.UpdateAvailable != true {
 		t.Fatal("expected to see update available, but reported as not available")
 	}
 	// make sure response got populated
@@ -201,9 +201,9 @@ func TestCachedCopyDoestRetrieveAgain(t *testing.T) {
 	// save to check later
 	r := cacheResponse
 
-	got = IsUpdateAvailable()
+	got, _ = CheckForUpdate("0.0.0")
 	// just make sure it is still true
-	if got != true {
+	if got.UpdateAvailable != true {
 		t.Fatal("expected to see update available, but reported as not available")
 	}
 

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -7,33 +7,25 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/HewlettPackard/hpecli/pkg/version"
 	goupdate "github.com/inconshreveable/go-update"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-// UpdateRun is by main to see if the update command was run
-// to suppress the message that and update is available
-var UpdateRun bool
-
-func NewUpdateCommand() *cobra.Command {
+func NewUpdateCommand(version string) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "update",
 		Short: "Update the hpecli executable",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			UpdateRun = true
-			return runUpdate()
+			return runUpdate(version)
 		},
 	}
 
 	return cmd
 }
 
-func runUpdate() error {
-	localVer := version.Get()
-
-	resp, err := checkUpdate(&jsonSource{url: versionURL}, localVer)
+func runUpdate(localVersion string) error {
+	resp, err := checkUpdate(&jsonSource{url: versionURL}, localVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -24,7 +24,7 @@ func TestUpdateWithNoUpdateAvailable(t *testing.T) {
 
 	versionURL = fmt.Sprintf("%s%s", ts.URL, "/json")
 
-	if err := runUpdate(); err != nil {
+	if err := runUpdate("0.0.0"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -39,20 +39,9 @@ func TestUpdateWithErrorInCheckUpdate(t *testing.T) {
 
 	defer ts.Close()
 
-	versionURL = ""
-
-	if err := runUpdate(); err == nil {
+	cmd := NewUpdateCommand("A")
+	if err := cmd.Execute(); err == nil {
 		t.Fatal("expected failure")
-	}
-}
-
-func TestUpdateRunSet(t *testing.T) {
-	UpdateRun = false
-
-	NewUpdateCommand().Execute()
-
-	if !UpdateRun {
-		t.Error("UpdateRun not set on command execution")
 	}
 }
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -4,115 +4,87 @@ package version
 
 import (
 	"testing"
-
-	"github.com/sirupsen/logrus"
 )
 
-const v1 = "0.0.1"
-const v0 = "0.0.0"
-const expectedError = "got: %v, want: %v"
+const incorrectValueError = "incorrect value: got=%v, want=%v"
 
-func TestGetDefault(t *testing.T) {
-	want := v0
-	got := Get()
-
-	if got != want {
-		t.Fatalf(expectedError, got, want)
-	}
-}
-
-func TestGet(t *testing.T) {
-	version = v1
-	want := v1
-	got := Get()
-
-	if got != want {
-		t.Fatalf(expectedError, got, want)
-	}
-}
-
-func TestGetFull(t *testing.T) {
-	version = v1
-	gitCommitID = "234a39f"
-	buildDate = "2019-01-01"
-	want := v1 + ":" + gitCommitID + ":" + buildDate
-	got := GetFull()
-
-	if got != want {
-		t.Fatalf(expectedError, got, want)
-	}
-}
-
-func TestCmdCreated(t *testing.T) {
-	cmd := NewVersionCommand()
-	if cmd == nil {
-		t.Fatal("command should have been initialized")
-	}
-}
-
-func TestIsFullVersion(t *testing.T) {
+func TestVersionInfoString(t *testing.T) {
 	cases := []struct {
-		verbose  bool
-		want     bool
-		logLevel logrus.Level
-		name     string
+		name string
+		want string
+		vi   *Info
 	}{
 		{
-			name:     "Default short",
-			verbose:  false,
-			logLevel: logrus.InfoLevel,
-			want:     false,
+			name: "NotVerbose",
+			vi: &Info{
+				BuildDate:   "A",
+				GitCommitID: "B",
+				Sematic:     "C",
+				Verbose:     false,
+			},
+			want: "C",
 		},
 		{
-			name:     "verbose is True",
-			verbose:  true,
-			logLevel: logrus.InfoLevel,
-			want:     true,
-		},
-		{
-			name:     "Debug LogLevel is verbose",
-			verbose:  false,
-			logLevel: logrus.DebugLevel,
-			want:     true,
+			name: "Verbose",
+			vi: &Info{
+				BuildDate:   "A",
+				GitCommitID: "B",
+				Sematic:     "C",
+				Verbose:     true,
+			},
+			want: "C:B:A",
 		},
 	}
 
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			logrus.SetLevel(c.logLevel)
-			got := isFullVersion(c.verbose)
+			got := c.vi.String()
 			if got != c.want {
-				t.Fatalf(expectedError, got, c.want)
+				t.Errorf(incorrectValueError, got, c.want)
 			}
 		})
 	}
 }
 
-func TestFullVersionOutput(t *testing.T) {
-	version = v0
-	gitCommitID = "0"
-	buildDate = "0"
-
-	// if values aren't injected at compile time
-	// then everything just defaults to 0
-	want := "0.0.0:0:0"
-
-	got := versionToShow(true)
-	if got != want {
-		t.Fatalf(expectedError, got, want)
+func TestVerboseFromCommandLine(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+		vi   *Info
+	}{
+		{
+			name: "NotVerbose",
+			args: []string{"-v"},
+			vi: &Info{
+				Verbose: false,
+			},
+			want: true,
+		},
+		{
+			name: "Verbose",
+			args: []string{"--verbose"},
+			vi: &Info{
+				Verbose: false,
+			},
+			want: true,
+		},
 	}
-}
 
-func TestRunVersion(t *testing.T) {
-	// if values aren't injected at compile time
-	// then everything just defaults to 0
-	want := v0
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			cmd := NewVersionCommand(c.vi)
 
-	logrus.SetLevel(logrus.InfoLevel)
+			cmd.SetArgs(c.args)
+			cmd.Execute()
 
-	got := versionToShow(false)
-	if got != want {
-		t.Fatalf(expectedError, got, want)
+			got := c.vi.Verbose
+
+			if got != c.want {
+				t.Errorf(incorrectValueError, got, c.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
instead of getting and printing the remote version on every invocation .. only do it when the actual version command is run.
It prints the local version and the remote version is an update is available.
