### PR TITLE
Didier/cloud volume work

### DIFF
--- a/pkg/cloudvolume/cloudvolume.go
+++ b/pkg/cloudvolume/cloudvolume.go
@@ -10,12 +10,13 @@ func NewCloudVolumeCommand() *cobra.Command {
 	// cmd represents the ilo command
 	var cmd = &cobra.Command{
 		Use:   "cloudvolumes",
-		Short: "Access to HPE Nimble Cloud Volumes commands",
+		Short: "Access to HPE Cloud Volumes commands",
 	}
 
 	cmd.AddCommand(
 		newGetCommand(),
 		newLoginCommand(),
+		newLogoutCommand(),
 	)
 
 	return cmd

--- a/pkg/cloudvolume/cloudvolume_test.go
+++ b/pkg/cloudvolume/cloudvolume_test.go
@@ -13,7 +13,7 @@ func TestCheckCmdCreation(t *testing.T) {
 		t.Error("name not set on command")
 	}
 
-	if len(cmd.Commands()) != 2 { //nolint:gomnd  // number ok here
+	if len(cmd.Commands()) != 3 { //nolint:gomnd  // number ok here
 		t.Error("unexpected discrepency in sub command count")
 	}
 }

--- a/pkg/cloudvolume/cvcontext.go
+++ b/pkg/cloudvolume/cvcontext.go
@@ -9,6 +9,10 @@ import (
 const cvAPIKeyPrefix = "hpecli_cloudvolume_token_"
 const cvContextKey = "hpecli_cloudvolume_context"
 
+const cvDefaultHost = "https://demo.cloudvolumes.hpe.com"
+
+
+
 func hostAndToken() (host, token string, err error) {
 	c := context.New(cvContextKey)
 
@@ -38,4 +42,18 @@ func saveData(apiEndpoint, token string) error {
 
 func dataKey(apiEndpoint string) string {
 	return cvAPIKeyPrefix + apiEndpoint
+}
+
+func hostData(host string) (token string, err error) {
+	c := context.New(cvContextKey)
+	if err = c.HostData(dataKey(host), &token); err != nil {
+		return "", err
+	}
+
+	return token, nil
+}
+
+func deleteSavedHostData(host string) error {
+	c := context.New(cvContextKey)
+	return c.DeleteHostData(dataKey(host))
 }

--- a/pkg/cloudvolume/get.go
+++ b/pkg/cloudvolume/get.go
@@ -10,7 +10,7 @@ func newGetCommand() *cobra.Command {
 	// cmd represents the cloudvolume command
 	var cmd = &cobra.Command{
 		Use:   "get",
-		Short: "Get resources from HPE Nimble Cloud Volumes",
+		Short: "Get resources from HPE Cloud Volumes",
 	}
 
 	cmd.AddCommand(

--- a/pkg/cloudvolume/login.go
+++ b/pkg/cloudvolume/login.go
@@ -34,9 +34,9 @@ func newLoginCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.host, "host", "", "Cloud Volumes portal hostname/ip")
-	cmd.Flags().StringVarP(&opts.username, "username", "u", "", "cloudvolume username")
-	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "cloudvolume passowrd")
+	cmd.Flags().StringVar(&opts.host, "host", "", "HPE Cloud Volumes portal hostname/ip")
+	cmd.Flags().StringVarP(&opts.username, "username", "u", "", "HPE Cloud Volumes username")
+	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "HPE Cloud Volumes passowrd")
 	cmd.Flags().BoolVarP(&opts.passwordStdin, "password-stdin", "", false, "read password from stdin")
 	// _ = cmd.MarkFlagRequired("host")
 	_ = cmd.MarkFlagRequired("username")
@@ -79,7 +79,7 @@ func runLogin(opts *cvLoginOptions) error {
 
 	token, err := cvc.login()
 	if err != nil {
-		logrus.Warningf("Unable to login with supplied credentials to HPE CloudVolume at: %s", opts.host)
+		logrus.Warningf("Unable to login with supplied credentials to HPE CloudVolumes at: %s", opts.host)
 		return err
 	}
 

--- a/pkg/cloudvolume/login.go
+++ b/pkg/cloudvolume/login.go
@@ -34,11 +34,10 @@ func newLoginCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.host, "host", "", "HPE Cloud Volumes portal hostname/ip")
+	cmd.Flags().StringVar(&opts.host, "host", cvDefaultHost, "HPE Cloud Volumes portal hostname/ip")
 	cmd.Flags().StringVarP(&opts.username, "username", "u", "", "HPE Cloud Volumes username")
 	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "HPE Cloud Volumes passowrd")
 	cmd.Flags().BoolVarP(&opts.passwordStdin, "password-stdin", "", false, "read password from stdin")
-	// _ = cmd.MarkFlagRequired("host")
 	_ = cmd.MarkFlagRequired("username")
 
 	return cmd

--- a/pkg/cloudvolume/login.go
+++ b/pkg/cloudvolume/login.go
@@ -25,7 +25,7 @@ func newLoginCommand() *cobra.Command {
 	// Cmd represents the cloudvolume get command
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Login to HPE Nimble Cloud Volumes: hpecli cloudvolumes login",
+		Short: "Login to HPE Cloud Volumes",
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			return validateArgs(&opts)
 		},
@@ -38,13 +38,19 @@ func newLoginCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.username, "username", "u", "", "cloudvolume username")
 	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "cloudvolume passowrd")
 	cmd.Flags().BoolVarP(&opts.passwordStdin, "password-stdin", "", false, "read password from stdin")
-	_ = cmd.MarkFlagRequired("host")
+	// _ = cmd.MarkFlagRequired("host")
 	_ = cmd.MarkFlagRequired("username")
 
 	return cmd
 }
 
 func validateArgs(opts *cvLoginOptions) error {
+
+
+	if opts.host == "" {
+		opts.host = cvDefaultHost
+	}
+
 	if opts.host != "" && !strings.HasPrefix(opts.host, "http") {
 		opts.host = fmt.Sprintf("https://%s", opts.host)
 	}
@@ -63,7 +69,7 @@ func validateArgs(opts *cvLoginOptions) error {
 func runLogin(opts *cvLoginOptions) error {
 	logrus.Debug("cloudvolumes/login called")
 
-	if err := password.Read(&opts.password, opts.passwordStdin, "cloudvolumes password: "); err != nil {
+	if err := password.Read(&opts.password, opts.passwordStdin, "HPE Cloud Volumes password: "); err != nil {
 		return err
 	}
 
@@ -73,17 +79,17 @@ func runLogin(opts *cvLoginOptions) error {
 
 	token, err := cvc.login()
 	if err != nil {
-		logrus.Warningf("Unable to login with supplied credentials to CloudVolume at: %s", opts.host)
+		logrus.Warningf("Unable to login with supplied credentials to HPE CloudVolume at: %s", opts.host)
 		return err
 	}
 
 	// change context to current host and save the token as the API key
 	// for subsequent requests
 	if err := saveData(opts.host, token); err != nil {
-		logrus.Warning("Successfully logged into CloudVolumes, but was unable to save the session data")
+		logrus.Warning("Successfully logged into HPE Cloud Volumes, but was unable to save the session data")
 		logrus.Debugf("%+v", err)
 	} else {
-		logrus.Infof("Successfully logged into CloudVolumes: %s", opts.host)
+		logrus.Infof("Successfully logged into HPE Cloud Volumes")
 	}
 
 	return nil

--- a/pkg/cloudvolume/login.go
+++ b/pkg/cloudvolume/login.go
@@ -36,7 +36,7 @@ func newLoginCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.host, "host", cvDefaultHost, "HPE Cloud Volumes portal hostname/ip")
 	cmd.Flags().StringVarP(&opts.username, "username", "u", "", "HPE Cloud Volumes username")
-	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "HPE Cloud Volumes passowrd")
+	cmd.Flags().StringVarP(&opts.password, "password", "p", "", "HPE Cloud Volumes password")
 	cmd.Flags().BoolVarP(&opts.passwordStdin, "password-stdin", "", false, "read password from stdin")
 	_ = cmd.MarkFlagRequired("username")
 

--- a/pkg/cloudvolume/login.go
+++ b/pkg/cloudvolume/login.go
@@ -45,11 +45,6 @@ func newLoginCommand() *cobra.Command {
 
 func validateArgs(opts *cvLoginOptions) error {
 
-
-	if opts.host == "" {
-		opts.host = cvDefaultHost
-	}
-
 	if opts.host != "" && !strings.HasPrefix(opts.host, "http") {
 		opts.host = fmt.Sprintf("https://%s", opts.host)
 	}

--- a/pkg/cloudvolume/logout.go
+++ b/pkg/cloudvolume/logout.go
@@ -20,11 +20,7 @@ func newLogoutCommand() *cobra.Command {
 			if host != "" && !strings.HasPrefix(host, "http") {
 				host = fmt.Sprintf("https://%s", host)
 			}
-
-			if host == "" {
-				host = cvDefaultHost
-			}
-
+			
 			return runLogout(host)
 		},
 	}

--- a/pkg/cloudvolume/logout.go
+++ b/pkg/cloudvolume/logout.go
@@ -33,14 +33,12 @@ func newLogoutCommand() *cobra.Command {
 func runLogout(host string) error {
 	logrus.Debug("Beginning runCloudVolumeLogout")
 	
-	host, token, err := hostAndToken()
+	host, _, err := hostAndToken()
 	if err != nil {
 		logrus.Debugf("unable to retrieve apiKey because of: %v", err)
 		return fmt.Errorf("Unable to retrieve the last login for HPE Cloud volumes. " +
 			"Please login to HPE Cloud Volumes using: hpe cloudvolumes login")
 	}
-
-	_ = newCVClientFromAPIKey(host, token)
 
 	// There is no API logout we can use
 	logrus.Infof("Successfully logged out of HPE Cloud Volumes")

--- a/pkg/cloudvolume/logout.go
+++ b/pkg/cloudvolume/logout.go
@@ -1,0 +1,65 @@
+// (C) Copyright 2019 Hewlett Packard Enterprise Development LP.
+
+package cloudvolume
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newLogoutCommand() *cobra.Command {
+	var host string
+
+	var cmd = &cobra.Command{
+		Use:   "logout",
+		Short: "Logout from HPE Cloud Volumes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if host != "" && !strings.HasPrefix(host, "http") {
+				host = fmt.Sprintf("https://%s", host)
+			}
+
+			if host == "" {
+				host = cvDefaultHost
+			}
+
+			return runLogout(host)
+		},
+	}
+
+
+	return cmd
+}
+
+func runLogout(host string) error {
+	logrus.Debug("Beginning runCloudVolumeLogout")
+	
+	if host == "" {
+		host = cvDefaultHost
+	}
+	token, err := hostData(host)
+	if err != nil {
+		logrus.Debugf("unable to retrieve apiKey because of: %v", err)
+		return fmt.Errorf("Unable to retrieve the last login for HPE Cloud volumes. " +
+			"Please login to HPE Cloud Volumes using: hpe cloudvolumes login")
+	}
+
+	//logrus.Warningf("Using CloudVolumes: %s", host)
+
+	_ = newCVClientFromAPIKey(host, token)
+
+	// There is no API logout we can use
+	logrus.Infof("Successfully logged out of HPE CloudVolumes")
+
+	// Cleanup context
+	err = deleteSavedHostData(host)
+	if err != nil {
+		logrus.Warning("Unable to cleanup the session data")
+		return err
+	}
+
+	return nil
+}
+

--- a/pkg/cloudvolume/logout.go
+++ b/pkg/cloudvolume/logout.go
@@ -29,6 +29,7 @@ func newLogoutCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&host, "host", cvDefaultHost, "HPE Cloud Volumes portal hostname/ip")
 
 	return cmd
 }
@@ -36,17 +37,12 @@ func newLogoutCommand() *cobra.Command {
 func runLogout(host string) error {
 	logrus.Debug("Beginning runCloudVolumeLogout")
 	
-	if host == "" {
-		host = cvDefaultHost
-	}
-	token, err := hostData(host)
+	host, token, err := hostAndToken()
 	if err != nil {
 		logrus.Debugf("unable to retrieve apiKey because of: %v", err)
 		return fmt.Errorf("Unable to retrieve the last login for HPE Cloud volumes. " +
 			"Please login to HPE Cloud Volumes using: hpe cloudvolumes login")
 	}
-
-	//logrus.Warningf("Using HPE Cloud Volumes: %s", host)
 
 	_ = newCVClientFromAPIKey(host, token)
 

--- a/pkg/cloudvolume/logout.go
+++ b/pkg/cloudvolume/logout.go
@@ -46,12 +46,12 @@ func runLogout(host string) error {
 			"Please login to HPE Cloud Volumes using: hpe cloudvolumes login")
 	}
 
-	//logrus.Warningf("Using CloudVolumes: %s", host)
+	//logrus.Warningf("Using HPE Cloud Volumes: %s", host)
 
 	_ = newCVClientFromAPIKey(host, token)
 
 	// There is no API logout we can use
-	logrus.Infof("Successfully logged out of HPE CloudVolumes")
+	logrus.Infof("Successfully logged out of HPE Cloud Volumes")
 
 	// Cleanup context
 	err = deleteSavedHostData(host)

--- a/pkg/cloudvolume/logout_test.go
+++ b/pkg/cloudvolume/logout_test.go
@@ -44,14 +44,6 @@ func TestLogoutNoHost(t *testing.T) {
 	// // clear everything from the mock store
 	context.MockClear()
 
-	mux := http.NewServeMux()
-	server := httptest.NewTLSServer(mux)
-	mux.HandleFunc("/rest/login-sessions", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	defer server.Close()
-
 	cmd := newLogoutCommand()
 	_ = cmd.Execute()
 

--- a/pkg/cloudvolume/logout_test.go
+++ b/pkg/cloudvolume/logout_test.go
@@ -1,0 +1,68 @@
+// (C) Copyright 2019 Hewlett Packard Enterprise Development LP.
+
+package cloudvolume
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/HewlettPackard/hpecli/internal/platform/context"
+)
+
+func init() {
+	context.DefaultDBOpenFunc = context.MockOpen
+}
+
+func TestLogoutHostPrefixAdded(t *testing.T) {
+	// // clear everything from the mock store
+	context.MockClear()
+
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	mux.HandleFunc("/rest/login-sessions", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	defer server.Close()
+
+	host := strings.Replace(server.URL, "https://", "", 1)
+
+	cmd := newLogoutCommand()
+	cmd.SetArgs([]string{"--host", host})
+	_ = cmd.Execute()
+
+	_, err := hostData(server.URL)
+	if !errors.Is(err, context.ErrorKeyNotFound) {
+		t.Fatal("logout should delete the context")
+	}
+}
+
+func TestLogoutSessionDataDeleted(t *testing.T) {
+	const sessionID = "HERE_IS_A_ID"
+
+	pathURI := "/redfish/v1/sessionservice/sessions/fooSession"
+
+	server := newTestServer(pathURI, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	defer server.Close()
+
+	host := server.URL
+
+	saveData(host, sessionID)
+
+	err := runLogout(host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = hostData(host)
+	if err != context.ErrorKeyNotFound {
+		t.Fatalf("expected ErrorKeyNotFound, but found %+v", err)
+	}
+}
+

--- a/pkg/cloudvolume/logout_test.go
+++ b/pkg/cloudvolume/logout_test.go
@@ -40,6 +40,27 @@ func TestLogoutHostPrefixAdded(t *testing.T) {
 	}
 }
 
+func TestLogoutNoHost(t *testing.T) {
+	// // clear everything from the mock store
+	context.MockClear()
+
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	mux.HandleFunc("/rest/login-sessions", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	defer server.Close()
+
+	cmd := newLogoutCommand()
+	_ = cmd.Execute()
+
+	_, err := hostData(server.URL)
+	if !errors.Is(err, context.ErrorKeyNotFound) {
+		t.Fatal("logout should delete the context")
+	}
+}
+
 func TestLogoutSessionDataDeleted(t *testing.T) {
 	const sessionID = "HERE_IS_A_ID"
 

--- a/pkg/cloudvolume/logout_test.go
+++ b/pkg/cloudvolume/logout_test.go
@@ -47,7 +47,7 @@ func TestLogoutNoHost(t *testing.T) {
 	cmd := newLogoutCommand()
 	_ = cmd.Execute()
 
-	_, err := hostData(server.URL)
+	_, err := hostData(cvDefaultHost)
 	if !errors.Is(err, context.ErrorKeyNotFound) {
 		t.Fatal("logout should delete the context")
 	}

--- a/pkg/cloudvolume/logout_test.go
+++ b/pkg/cloudvolume/logout_test.go
@@ -5,8 +5,6 @@ package cloudvolume
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/HewlettPackard/hpecli/internal/platform/context"
@@ -16,33 +14,19 @@ func init() {
 	context.DefaultDBOpenFunc = context.MockOpen
 }
 
-func TestLogoutHostPrefixAdded(t *testing.T) {
-	// // clear everything from the mock store
-	context.MockClear()
-
-	mux := http.NewServeMux()
-	server := httptest.NewTLSServer(mux)
-	mux.HandleFunc("/rest/login-sessions", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	defer server.Close()
-
-	host := strings.Replace(server.URL, "https://", "", 1)
+func TestLogoutHost(t *testing.T) {
 
 	cmd := newLogoutCommand()
-	cmd.SetArgs([]string{"--host", host})
+	cmd.SetArgs([]string{"--host", cvDefaultHost})
 	_ = cmd.Execute()
 
-	_, err := hostData(server.URL)
+	_, err := hostData(cvDefaultHost)
 	if !errors.Is(err, context.ErrorKeyNotFound) {
 		t.Fatal("logout should delete the context")
 	}
 }
 
 func TestLogoutNoHost(t *testing.T) {
-	// // clear everything from the mock store
-	context.MockClear()
 
 	cmd := newLogoutCommand()
 	_ = cmd.Execute()

--- a/pkg/cloudvolume/volumes.go
+++ b/pkg/cloudvolume/volumes.go
@@ -12,7 +12,7 @@ import (
 func newGetVolumesCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "volumes",
-		Short: "retrieve volumes from Cloud Volumes",
+		Short: "retrieve volumes from HPE Cloud Volumes",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runGetVolumes()
 		},
@@ -28,10 +28,10 @@ func runGetVolumes() error {
 	if err != nil {
 		logrus.Debugf("unable to retrieve apiKey because of: %v", err)
 		return fmt.Errorf("unable to retrieve the last login for HPE CloudVolumes. " +
-			"Please login to CloudVolumes using: hpe cloudvolumes login")
+			"Please login to HPE Cloud Volumes using: hpe cloudvolumes login")
 	}
 
-	logrus.Debugf("Attempting get cloud volumes at: %v", host)
+	logrus.Debugf("Attempting get cloudvolumes at: %v", host)
 
 	cvc := newCVClientFromAPIKey(host, token)
 

--- a/pkg/cloudvolume/volumes.go
+++ b/pkg/cloudvolume/volumes.go
@@ -12,7 +12,7 @@ import (
 func newGetVolumesCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "volumes",
-		Short: "Get from Cloud Volumes: hpecli cloudvolumes get volumes",
+		Short: "retrieve volumes from Cloud Volumes",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runGetVolumes()
 		},
@@ -27,8 +27,8 @@ func runGetVolumes() error {
 	host, token, err := hostAndToken()
 	if err != nil {
 		logrus.Debugf("unable to retrieve apiKey because of: %v", err)
-		return fmt.Errorf("unable to retrieve the last login for HPE CloudVolumes.  " +
-			"Please login to CloudVolumes using: hpecli cloudvolume login")
+		return fmt.Errorf("unable to retrieve the last login for HPE CloudVolumes. " +
+			"Please login to CloudVolumes using: hpe cloudvolumes login")
 	}
 
 	logrus.Debugf("Attempting get cloud volumes at: %v", host)


### PR DESCRIPTION
1. Removed all hpecli reference in strings, and used HPE Cloud Volumes consistently

2. added a logout command although there is no logout in API that I could find. We simple delete the context. 

3. changed the --host param in login to not be mandatory and used a "default" value for Cloud Volume URL (https://demo.cloudvolumes.hpe.com/ ) which should be changed to cloudvolumes.hpe.com later