### PR TITLE
Added check early on for no args

### DIFF
--- a/cmd/hpecli/main.go
+++ b/cmd/hpecli/main.go
@@ -57,6 +57,12 @@ func run() error {
 	// add all of the commands get added to this root one
 	addSubCommands(rootCmd)
 
+	// Are we are been called with no args at all?
+	if len(os.Args) == 1 {
+		// Then let's return the command usage as in: hpe --help
+		os.Args = []string{os.Args[0], "--help"} 
+	}  
+
 	// execute the root command
 	if err := rootCmd.Execute(); err != nil {
 		return err


### PR DESCRIPTION
The case is detected and handled like if hpe --help was called instead.